### PR TITLE
fix error with missing id

### DIFF
--- a/lib/terminal_component.ex
+++ b/lib/terminal_component.ex
@@ -6,7 +6,7 @@ defmodule Underthehood.TerminalComponent do
   def render(assigns) do
     ~H"""
     <div phx-hook="Terminal" id={@id}>
-      <div class="xtermjs_container" phx-update="ignore"></div>
+      <div class="xtermjs_container" phx-update="ignore" id={"xtermjs-container-#{@id}"}></div>
     </div>
     """
   end


### PR DESCRIPTION
on a fresh install I was getting this error:

```== Compilation error in file lib/terminal_component.ex ==
** (Phoenix.LiveView.HTMLTokenizer.ParseError) lib/terminal_component.ex:9:7: attribute "phx-update" requires the "id" attribute to be set
    (phoenix_live_view 0.18.0-dev) lib/phoenix_live_view/html_engine.ex:1038: Phoenix.LiveView.HTMLEngine.validate_phx_attrs!/5
    (phoenix_live_view 0.18.0-dev) lib/phoenix_live_view/html_engine.ex:521: Phoenix.LiveView.HTMLEngine.handle_token/2
    (elixir 1.12.2) lib/enum.ex:2385: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix_live_view 0.18.0-dev) lib/phoenix_live_view/html_engine.ex:124: Phoenix.LiveView.HTMLEngine.handle_body/1
    (phoenix_live_view 0.18.0-dev) expanding macro: Phoenix.LiveView.Helpers.sigil_H/2
    lib/terminal_component.ex:7: Underthehood.TerminalComponent.render/1
    (elixir 1.12.2) lib/kernel/parallel_compiler.ex:319: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```