### PR TITLE
Simplify referencing underthehood JavaScript logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 2. Register a Phoenix hook by editing the `app.js` script of your Phoenix project. This typically
 amounts to registering a hook along these lines:
 ```javascript
-import TerminalHook from "../../deps/underthehood/lib/hook"
+import TerminalHook from "underthehook"
 
 let Hooks = {}
 Hooks.Terminal = TerminalHook

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "underthehood",
+  "version": "0.1.3",
+  "main": "lib/hook.js",
+  "repository": {
+  },
+  "files": ["README.md", "package.json", "lib/hook.js"]
+}


### PR DESCRIPTION
Instead of hardcoding the full path to the hook.js file, we can provide a package.json file which references the 'main' JavaScript source. This source file is then loaded by client applications by just saying

```javascript
  import TerminalHook from "underthehood"
```