### PR TITLE
Fixed setting up Elixir during CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       MIX_ENV: test
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Elixir
-        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: 1.13.4
           otp-version: 24.1


### PR DESCRIPTION
CI runs would bail out in the 'Set up Elixir' step, printing

```
  Error: Tried to map a target OS from env. variable 'ImageOS' (got
  ubuntu22), but failed. If you're using a self-hosted runner, you should
  set 'env': 'ImageOS': ... to one of the following: ['ubuntu16',
  'ubuntu18', 'ubuntu20', 'win16', 'win19']
```

It appears that this is because 'ubuntu-latest' corresponds to 'ubuntu22' but the setup-beam action doesn't know that. Looking at other projects showed that they use 'runs-on' with a specific image version, let's see if that works better.

Let's also not hardcode a setup-erlef hash but just use @v1.